### PR TITLE
Add link to SE2022 presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ recordings for the presentations given at the workshop:
 ### Presentations
 
 - [HERMES introductory slides from the HMC Welcome Meeting](https://helmholtz-metadaten.de/download/projects/07_HERMES_HMC.pdf) - 2021-04-13
+- ["HERMES: Automated software publication with rich metadata"](https://doi.org/10.5281/zenodo.6241553) (Presentation given at [SE2022](https://se-2022.gi.de/)) - 2022-02-23
 
 ## Giving feedback on the HERMES project
 


### PR DESCRIPTION
Adds a link to the Zenodo publication of the slides for SE2022.